### PR TITLE
Add dashboard setup guidance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # portfolio
 showcase for projects &amp; assorted small ideas
+
+## Dashboard setup (pip/venv)
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Required dependencies
+At minimum, install:
+- streamlit
+- plotly
+- yfinance
+- pandas
+
+## Launch
+```bash
+streamlit run dashboard/app.py
+```
+
+## API limits and refresh guidance
+- Data providers like Yahoo Finance can throttle or rate-limit requests; excessive refreshes may lead to temporary blocks.
+- Suggested refresh frequency: every 5–15 minutes for interactive use, and less often for unattended dashboards.


### PR DESCRIPTION
### Motivation
- Provide developers a quick-start for running the dashboard by documenting a `pip`/`venv` setup, required dependencies, launch command, and API/refresh guidance in `README.md`.

### Description
- Update `README.md` to add a "Dashboard setup (pip/venv)" section with `python -m venv .venv`, `pip install -r requirements.txt`, a minimal dependency list (`streamlit`, `plotly`, `yfinance`, `pandas`), the launch command `streamlit run dashboard/app.py`, and notes about API limits and suggested refresh frequency.

### Testing
- No automated tests were run because this is a documentation-only change; commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826615cc3c8328b66daa3d82952fec)